### PR TITLE
Adding RepositoryUrl to csproj

### DIFF
--- a/RippLib.Util/RippLib.Util.csproj
+++ b/RippLib.Util/RippLib.Util.csproj
@@ -12,6 +12,8 @@
     <Copyright>Ben Luts</Copyright>
     <PackageLicenseUrl>https://github.com/BenLuts/RippLib.Util/blob/master/LICENSE</PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/BenLuts/RippLib.Util</PackageProjectUrl>
+    <RepositoryUrl>https://github.com/BenLuts/RippLib.Util</RepositoryUrl>
+    <RepositoryType>git</RepositoryType>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This allows for multiple URLs to eventually move the `ProjectUrl` to a full website instead of being stuck with GitHub.

See the relevant [blog post](https://blog.nuget.org/20180827/Introducing-Source-Code-Link-for-NuGet-packages.html). 